### PR TITLE
AWS: Policy Create and Update Changes

### DIFF
--- a/internal/service/iam/policy.go
+++ b/internal/service/iam/policy.go
@@ -255,8 +255,8 @@ func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			return sdkdiag.AppendErrorf(diags, "creating IAM Policy (%s): %s", d.Id(), err)
 		}
 
-		// Ensuring Thread Sleeps for 3 seconds before Setting version as default version
-		time.Sleep(3 * time.Second)
+		// Ensuring Thread Sleeps for 10 seconds before Setting version as default version
+		time.Sleep(10 * time.Second)
 		policyInput := &iam.SetDefaultPolicyVersionInput{
 			PolicyArn: aws.String(d.Id()),
 			VersionId: policyVersionOutput.PolicyVersion.VersionId,

--- a/internal/service/iam/policy.go
+++ b/internal/service/iam/policy.go
@@ -256,7 +256,7 @@ func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 
 		// Ensuring Thread Sleeps for 3 seconds before Setting version as default version
-		time.Sleep(10 * time.Second)
+		time.Sleep(3 * time.Second)
 		policyInput := &iam.SetDefaultPolicyVersionInput{
 			PolicyArn: aws.String(d.Id()),
 			VersionId: policyVersionOutput.PolicyVersion.VersionId,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Currently, when policies are applied, the AWS Terraform provider executes two actions simultaneously:

Creates a policy version.
Sets the new policy version as the default.
During this process, the short duration for these operations can cause tokens issued in this timeframe to be inconsistent, and can lead to 403 errors for users and services.
Upon investigation, introducing a 3-second delay was found to significantly reduce the occurrence of these 403 errors. This pull request implements a 10-second pause before setting the policy version as the default, improving overall reliability.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
